### PR TITLE
Bug: On a Pixel 4, sometimes, you get no mDns results

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,7 +29,7 @@ Import the library in your app's module ```build.gradle```
 ```groovy
 dependencies {
     ...
-    implementation 'com.github.inthepocket:rxbonjour:1.0.9'
+    implementation 'com.github.inthepocket:rxbonjour:1.0.10'
 }
 ```
 

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     package="com.xiao.rxbonjour">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
+
     <application />
 
 </manifest>

--- a/lib/src/main/java/com/xiao/rxbonjour/discovery/JBDiscoveryOnSubscribeEvent.java
+++ b/lib/src/main/java/com/xiao/rxbonjour/discovery/JBDiscoveryOnSubscribeEvent.java
@@ -3,6 +3,7 @@ package com.xiao.rxbonjour.discovery;
 import android.content.Context;
 import android.net.nsd.NsdManager;
 import android.net.nsd.NsdServiceInfo;
+import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
@@ -26,8 +27,10 @@ import static com.xiao.rxbonjour.model.NsdStatus.REMOVED;
 public class JBDiscoveryOnSubscribeEvent implements OnSubscribeEvent<NsdServiceInfoWrapper> {
 
     private NsdManager nsdManager;
+    private WifiManager wifiManager;
     private final String protocol;
     private ObservableEmitter<? super NsdServiceInfoWrapper> emitter;
+    private WifiManager.MulticastLock multicastLock;
 
 
     public JBDiscoveryOnSubscribeEvent(@NonNull final Context context,
@@ -35,12 +38,16 @@ public class JBDiscoveryOnSubscribeEvent implements OnSubscribeEvent<NsdServiceI
 
         this.protocol = protocol;
         this.nsdManager = (NsdManager) context.getSystemService(Context.NSD_SERVICE);
+        this.wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
     }
 
     private final Action dismissAction = new Action() {
         @Override
         public void run() throws Exception {
             if (nsdManager != null) {
+                // release lock 👼
+                multicastLock.release();
+                
                 nsdManager.stopServiceDiscovery(discoveryListener);
                 nsdManager = null;
             }
@@ -94,6 +101,11 @@ public class JBDiscoveryOnSubscribeEvent implements OnSubscribeEvent<NsdServiceI
         if (!NsdUtils.isValidProtocol(protocol)) {
             emitter.onError(new NsdException());
         } else {
+            // get lock 👼
+            WifiManager.MulticastLock multicastLock = wifiManager.createMulticastLock("rxBonjourMulticastLock");
+            multicastLock.setReferenceCounted(true);
+            multicastLock.acquire();
+
             nsdManager.discoverServices(protocol, NsdManager.PROTOCOL_DNS_SD, discoveryListener);
             emitter.setCancellable(new Cancellable() {
                 @Override

--- a/lib/src/main/java/com/xiao/rxbonjour/discovery/JBDiscoveryOnSubscribeEvent.java
+++ b/lib/src/main/java/com/xiao/rxbonjour/discovery/JBDiscoveryOnSubscribeEvent.java
@@ -102,7 +102,7 @@ public class JBDiscoveryOnSubscribeEvent implements OnSubscribeEvent<NsdServiceI
             emitter.onError(new NsdException());
         } else {
             // get lock 👼
-            WifiManager.MulticastLock multicastLock = wifiManager.createMulticastLock("rxBonjourMulticastLock");
+            multicastLock = wifiManager.createMulticastLock("rxBonjourMulticastLock");
             multicastLock.setReferenceCounted(true);
             multicastLock.acquire();
 


### PR DESCRIPTION
Problem; On a Pixel 4, sometimes no mDns results are returned (either via the WifiManager or the NsdManager). This might be due to battery optimisation. Acquiring a multicastlock via the WifiManager solves the issue and guarantees results.

Links & resources:

-  Others that discovered this problem:
    - [https://stackoverflow.com/questions/53615125/nsdmanager-discovery-does-not-work-on-android-9](https://stackoverflow.com/questions/53615125/nsdmanager-discovery-does-not-work-on-android-9)
    - [https://github.com/andriydruk/RxDNSSD/issues/38](https://github.com/andriydruk/RxDNSSD/issues/38)
- Example fix: [https://github.com/andriydruk/RxDNSSD/blob/01300a1d36c4713ac17bcf77edd42ef3858b699f/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java](https://github.com/andriydruk/RxDNSSD/blob/01300a1d36c4713ac17bcf77edd42ef3858b699f/dnssd/src/main/java/com/github/druk/dnssd/DNSSD.java)
- Android developer resources:
    - [https://developer.android.com/reference/android/Manifest.permission#CHANGE_WIFI_MULTICAST_STATE](https://developer.android.com/reference/android/Manifest.permission#CHANGE_WIFI_MULTICAST_STATE)
    - [https://developer.android.com/reference/android/net/wifi/WifiManager.MulticastLock](https://developer.android.com/reference/android/net/wifi/WifiManager.MulticastLock)